### PR TITLE
Rename insights to blog

### DIFF
--- a/build/js/global.js
+++ b/build/js/global.js
@@ -27,7 +27,7 @@ ubuntu.globalNav = function () {
   }
 
   return {
-    sites: [{ url: "http://www.ubuntu.com", title: "Ubuntu" }, { url: "https://community.ubuntu.com/", title: "Community" }, { url: "https://askubuntu.com", title: "Ask!" }, { url: "https://developer.ubuntu.com", title: "Developer" }, { url: "https://design.ubuntu.com", title: "Design" }, { url: "https://certification.ubuntu.com", title: "Hardware" }, { url: "https://insights.ubuntu.com", title: "Insights" }, { url: "https://jujucharms.com", title: "Juju" }, { url: "http://maas.ubuntu.com", title: "MAAS" }, { url: "http://partners.ubuntu.com", title: "Partners" }, { url: "https://buy.ubuntu.com/", title: "Shop" }],
+    sites: [{ url: "http://www.ubuntu.com", title: "Ubuntu" }, { url: "https://community.ubuntu.com/", title: "Community" }, { url: "https://askubuntu.com", title: "Ask!" }, { url: "https://developer.ubuntu.com", title: "Developer" }, { url: "https://design.ubuntu.com", title: "Design" }, { url: "https://certification.ubuntu.com", title: "Hardware" }, { url: "https://blog.ubuntu.com", title: "Blog" }, { url: "https://jujucharms.com", title: "Juju" }, { url: "http://maas.ubuntu.com", title: "MAAS" }, { url: "http://partners.ubuntu.com", title: "Partners" }, { url: "https://buy.ubuntu.com/", title: "Shop" }],
 
     more: [{ url: "https://help.ubuntu.com", title: "Help" }, { url: "https://ubuntuforums.org", title: "Forum" }, { url: "https://www.launchpad.net", title: "Launchpad" }, { url: "https://shop.canonical.com", title: "Merchandise" }, { url: "http://www.canonical.com", title: "Canonical" }, { url: "https://conjure-up.io", title: "conjure-up" }],
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "global-nav",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "A script and stylesheet that displays the Canonical global nav across the top of a site",
   "main": "index.js",
   "scripts": {

--- a/src/js/global.js
+++ b/src/js/global.js
@@ -32,7 +32,7 @@ ubuntu.globalNav = function() {
       { url: "https://developer.ubuntu.com", title:"Developer" },
       { url: "https://design.ubuntu.com", title:"Design" },
       { url: "https://certification.ubuntu.com", title:"Hardware" },
-      { url: "https://insights.ubuntu.com", title:"Insights" },
+      { url: "https://blog.ubuntu.com", title:"Blog" },
       { url: "https://jujucharms.com", title:"Juju" },
       { url: "http://maas.ubuntu.com", title:"MAAS" },
       { url: "http://partners.ubuntu.com", title:"Partners" },


### PR DESCRIPTION
## Done
- Rename insights.ubuntu.com to blog.ubuntu.com 

## QA
- Clone repo and run a local dev server inside the `/build` directory
- Make sure that there is not an `insights` link in the navigation
- Make sure that there is a `blog` link in the navigation

## Issue / Card
Fixes [#512](https://github.com/ubuntudesign/web-squad/issues/512)