### PR TITLE
Update the livepatch login link

### DIFF
--- a/src/js/product-details.js
+++ b/src/js/product-details.js
@@ -149,7 +149,7 @@ const canonicalLogins = [
     title: 'Livepatch',
     logoUrl: 'https://assets.ubuntu.com/v1/47ba7e44-picto-canonical-white.svg',
     description: 'Apply critical kernel security fixes without rebooting',
-    login: 'https://livepatch.canonical.com/',
+    login: 'https://auth.livepatch.canonical.com/',
     signup: 'https://auth.livepatch.canonical.com/',
   }, {
     title: 'Launchpad.net',


### PR DESCRIPTION
## Done

* updated the livepatch login link to point to auth.livepatch.canonical.com as livepatch.canonical.com doesn't have any information

Fixes #50