### PR TITLE
Use UMD export format

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -9,32 +9,48 @@ import postcss from 'postcss';
 
 import pkg from './package.json';
 
-export default {
-  input: 'src/index.js',
-  output: {
-    file: pkg.main,
-    format: 'umd',
-    name: 'canonicalGlobalNav',
-    sourcemap: true,
+export default [
+  {
+    input: 'src/index.js',
+    output: {
+      file: pkg.main,
+      format: 'umd',
+      name: 'canonicalGlobalNav',
+      sourcemap: true,
+    },
+    plugins: [
+      babel({
+        babelrc: false,
+        exclude: ['node_modules/**', 'src/**/*.scss'],
+        presets: [['env', { modules: false }], 'stage-0'],
+        plugins: ['external-helpers'],
+      }),
+      commonjs(),
+      resolve(),
+      sass({
+        insert: true,
+        processor: css => postcss([autoprefixer, cssnano])
+          .process(css)
+          .then(result => result.css),
+      }),
+      uglify(),
+    ],
   },
-  plugins: [
-    babel({
-      babelrc: false,
-      exclude: ['node_modules/**', 'src/**/*.scss'],
-      presets: [
-        ['env', { modules: false }],
-        'stage-0',
-      ],
-      plugins: ['external-helpers'],
-    }),
-    commonjs(),
-    resolve(),
-    sass({
-      insert: true,
-      processor: css => postcss([autoprefixer, cssnano])
-        .process(css)
-        .then(result => result.css),
-    }),
-    uglify(),
-  ],
-};
+  {
+    input: 'test/es6-import-test.js',
+    output: {
+      file: 'dist/es6-import-test.js',
+      format: 'umd',
+      name: 'es6-import-test',
+    },
+    plugins: [
+      babel({
+        babelrc: false,
+        exclude: ['dist/**'],
+        presets: [['env', { modules: false }], 'stage-0'],
+        plugins: ['external-helpers'],
+      }),
+      commonjs(),
+    ],
+  },
+];

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -13,7 +13,7 @@ export default {
   input: 'src/index.js',
   output: {
     file: pkg.main,
-    format: 'iife',
+    format: 'umd',
     name: 'canonicalGlobalNav',
     sourcemap: true,
   },

--- a/test/es6-import-test.js
+++ b/test/es6-import-test.js
@@ -1,0 +1,3 @@
+import canonicalGlobalNav from '../dist/index';
+
+canonicalGlobalNav.createNav();

--- a/test/index-es6-import.html
+++ b/test/index-es6-import.html
@@ -1,0 +1,57 @@
+<!doctype html>
+<html class="no-js" lang="">
+    <head>
+        <meta charset="utf-8">
+        <meta http-equiv="x-ua-compatible" content="ie=edge">
+        <title>Canonical global navigation demo</title>
+        <meta name="description" content="Canonical global navigation demo">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+	<style type="text/css">
+		body {
+			display: block;
+			height: 100%;
+			margin: 0;
+			width: 100%;
+		}
+	</style>
+    </head>
+    <body>
+        <h1>Page content</h1>
+        <p>This is the demo of the global navigation project for Canonicals websites.</p>
+		<div id="lipsum">
+			<p>
+			Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris non mi justo. Mauris nisi neque, posuere sed consequat vel, aliquet id nulla. Aliquam nec velit elit. Nam eu sapien nisl. Morbi mattis viverra leo a lobortis. Aenean at nisl lobortis, tristique odio ac, porta massa. Curabitur vehicula malesuada turpis in varius. Pellentesque leo neque, vehicula sed porttitor eu, hendrerit vel lacus. Suspendisse suscipit ultricies erat id facilisis. Ut hendrerit vitae ex nec convallis.
+			</p>
+			<p>
+			Nunc scelerisque, mi vitae fringilla euismod, arcu nisl dignissim neque, nec accumsan ante risus ut ipsum. Pellentesque vulputate odio turpis. Nunc sed semper dui, ut tempor nulla. Nullam consectetur fermentum ligula eu eleifend. Morbi ullamcorper gravida mauris. Cras sed massa eu ante convallis pulvinar. Pellentesque interdum sollicitudin elit, et efficitur purus varius vitae. Morbi euismod faucibus sapien id laoreet. Quisque euismod est bibendum lorem ultricies, nec facilisis nibh lobortis. Fusce in tempor justo, ut mollis orci. Sed sem purus, tristique a magna sit amet, sollicitudin lobortis ipsum. Proin mauris eros, pretium at magna ac, rhoncus tristique nulla.
+			</p>
+			<p>
+			Nullam blandit purus et nulla vehicula, sit amet convallis erat ullamcorper. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Vestibulum dignissim placerat velit in mollis. Quisque sed magna nisi. Praesent varius congue felis sit amet scelerisque. Phasellus purus lorem, porta sit amet eleifend et, dapibus imperdiet erat. Nunc dictum nibh quis convallis imperdiet. Praesent ut diam eget eros auctor sollicitudin nec id urna. In ante nisl, facilisis vitae mauris in, faucibus fringilla justo. Nunc rhoncus purus et tellus imperdiet finibus.
+			</p>
+			<p>
+			Quisque ullamcorper eros mauris, non eleifend leo sagittis nec. Aenean ut ex id lorem sagittis dapibus. Pellentesque consequat sapien erat, quis cursus augue ultrices in. Mauris nec venenatis nisi. Integer gravida semper elit sagittis finibus. Vestibulum convallis odio et leo imperdiet, non molestie eros posuere. Quisque egestas nulla a libero pretium, nec pulvinar mauris vestibulum. Pellentesque vehicula dolor nulla, eu feugiat dolor tempor congue. Duis id tincidunt quam. In hac habitasse platea dictumst. Mauris tempus tortor eget sapien ultrices egestas. Nulla facilisi. Nulla hendrerit quis ante a viverra. Maecenas eu egestas libero.
+			</p>
+			<p>
+			Curabitur ut lacus vitae massa congue sagittis vitae blandit magna. Fusce pharetra arcu risus, a tempor tortor convallis vitae. Sed varius fermentum metus, id placerat eros hendrerit ullamcorper. Suspendisse porta felis odio, eu sollicitudin dui tristique ut. Ut ullamcorper leo nec sodales tempus. Nunc porttitor et libero in dignissim. Proin euismod eleifend erat. Vivamus nec aliquam ex. Ut aliquet venenatis diam, vitae sollicitudin ligula suscipit vel. Suspendisse et justo sapien. Etiam eleifend mauris non orci fringilla vulputate. Ut imperdiet magna faucibus, sagittis ex eu, sagittis tellus. Vestibulum faucibus vestibulum arcu non dictum. Nullam quis volutpat arcu, sit amet viverra ante.
+			</p>
+		</div>
+		<div id="lipsum">
+			<p>
+			Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris non mi justo. Mauris nisi neque, posuere sed consequat vel, aliquet id nulla. Aliquam nec velit elit. Nam eu sapien nisl. Morbi mattis viverra leo a lobortis. Aenean at nisl lobortis, tristique odio ac, porta massa. Curabitur vehicula malesuada turpis in varius. Pellentesque leo neque, vehicula sed porttitor eu, hendrerit vel lacus. Suspendisse suscipit ultricies erat id facilisis. Ut hendrerit vitae ex nec convallis.
+			</p>
+			<p>
+			Nunc scelerisque, mi vitae fringilla euismod, arcu nisl dignissim neque, nec accumsan ante risus ut ipsum. Pellentesque vulputate odio turpis. Nunc sed semper dui, ut tempor nulla. Nullam consectetur fermentum ligula eu eleifend. Morbi ullamcorper gravida mauris. Cras sed massa eu ante convallis pulvinar. Pellentesque interdum sollicitudin elit, et efficitur purus varius vitae. Morbi euismod faucibus sapien id laoreet. Quisque euismod est bibendum lorem ultricies, nec facilisis nibh lobortis. Fusce in tempor justo, ut mollis orci. Sed sem purus, tristique a magna sit amet, sollicitudin lobortis ipsum. Proin mauris eros, pretium at magna ac, rhoncus tristique nulla.
+			</p>
+			<p>
+			Nullam blandit purus et nulla vehicula, sit amet convallis erat ullamcorper. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Vestibulum dignissim placerat velit in mollis. Quisque sed magna nisi. Praesent varius congue felis sit amet scelerisque. Phasellus purus lorem, porta sit amet eleifend et, dapibus imperdiet erat. Nunc dictum nibh quis convallis imperdiet. Praesent ut diam eget eros auctor sollicitudin nec id urna. In ante nisl, facilisis vitae mauris in, faucibus fringilla justo. Nunc rhoncus purus et tellus imperdiet finibus.
+			</p>
+			<p>
+			Quisque ullamcorper eros mauris, non eleifend leo sagittis nec. Aenean ut ex id lorem sagittis dapibus. Pellentesque consequat sapien erat, quis cursus augue ultrices in. Mauris nec venenatis nisi. Integer gravida semper elit sagittis finibus. Vestibulum convallis odio et leo imperdiet, non molestie eros posuere. Quisque egestas nulla a libero pretium, nec pulvinar mauris vestibulum. Pellentesque vehicula dolor nulla, eu feugiat dolor tempor congue. Duis id tincidunt quam. In hac habitasse platea dictumst. Mauris tempus tortor eget sapien ultrices egestas. Nulla facilisi. Nulla hendrerit quis ante a viverra. Maecenas eu egestas libero.
+			</p>
+			<p>
+			Curabitur ut lacus vitae massa congue sagittis vitae blandit magna. Fusce pharetra arcu risus, a tempor tortor convallis vitae. Sed varius fermentum metus, id placerat eros hendrerit ullamcorper. Suspendisse porta felis odio, eu sollicitudin dui tristique ut. Ut ullamcorper leo nec sodales tempus. Nunc porttitor et libero in dignissim. Proin euismod eleifend erat. Vivamus nec aliquam ex. Ut aliquet venenatis diam, vitae sollicitudin ligula suscipit vel. Suspendisse et justo sapien. Etiam eleifend mauris non orci fringilla vulputate. Ut imperdiet magna faucibus, sagittis ex eu, sagittis tellus. Vestibulum faucibus vestibulum arcu non dictum. Nullam quis volutpat arcu, sit amet viverra ante.
+			</p>
+		</div>
+		<script src="../dist/es6-import-test.js"></script>
+    </body>
+</html>


### PR DESCRIPTION
Currently global-nav is exported as IIFE making it only usable as external script included via `<script>` tag in HTML.
It makes it hard to use global-nav in bundled apps (such as build.snapcraft.io for example).

Exporting as UMD format keeps backwards compatibility with IIFE (making it stil possible to import via `<script>` tag), but adds possibility to import/require global-nav in bundled apps:

```js
import { createNav } from 'global-nav';
```

### QA
- yarn build
- open `index.html` - make sure global-nav works as before when included via script tag
- open `test/index-es6-import.html` - make sure that global-nav works as expected with imported via module