### PR TITLE
Fix backwards compatibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -138,7 +138,7 @@
         ante.
       </p>
     </div>
-    <script src="dist/iife.js"></script>
+    <script src="dist/index.js"></script>
     <script>
       canonicalGlobalNav.createNav();
     </script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "global-nav",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "global-nav",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "global-nav",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "A script and stylesheet that displays the Canonical global nav across the top of a site",
   "main": "dist/module.js",
   "iife": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "global-nav",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "A script and stylesheet that displays the Canonical global nav across the top of a site",
   "main": "dist/index.js",
   "iife": "dist/iife.js",

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "global-nav",
   "version": "2.0.2",
   "description": "A script and stylesheet that displays the Canonical global nav across the top of a site",
-  "main": "dist/index.js",
-  "iife": "dist/iife.js",
+  "main": "dist/module.js",
+  "iife": "dist/index.js",
   "scripts": {
     "build": "rm -rf dist && rollup -c",
     "prettier-check": "prettier **/* --check",


### PR DESCRIPTION
- Swap dist target for main to be `"main": "dist/module.js"` and make the `iife` target the default `"dist/index.js"`
- Bump version to 2.0.3

## QA

- Sanity check code
- Run demo locally