### PR TITLE
Add Instant Page lib for just-in-time preloading

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,13 +22,14 @@
     </p>
     <div id="lipsum">
       <p>
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris non mi
-        justo. Mauris nisi neque, posuere sed consequat vel, aliquet id nulla.
-        Aliquam nec velit elit. Nam eu sapien nisl. Morbi mattis viverra leo a
-        lobortis. Aenean at nisl lobortis, tristique odio ac, porta massa.
-        Curabitur vehicula malesuada turpis in varius. Pellentesque leo neque,
-        vehicula sed porttitor eu, hendrerit vel lacus. Suspendisse suscipit
-        ultricies erat id facilisis. Ut hendrerit vitae ex nec convallis.
+        Lorem <a href="/foo">ipsum</a> dolor sit amet, consectetur adipiscing
+        elit. Mauris non mi justo. Mauris nisi neque, posuere sed consequat vel,
+        aliquet id nulla. Aliquam nec velit elit. Nam eu sapien nisl. Morbi
+        mattis viverra leo a lobortis. Aenean at nisl lobortis, tristique odio
+        ac, porta massa. Curabitur vehicula malesuada turpis in varius.
+        Pellentesque leo neque, vehicula sed porttitor eu, hendrerit vel lacus.
+        Suspendisse suscipit ultricies erat id facilisis. Ut hendrerit vitae ex
+        nec convallis.
       </p>
       <p>
         Nunc scelerisque, mi vitae fringilla euismod, arcu nisl dignissim neque,

--- a/src/js/global-nav.js
+++ b/src/js/global-nav.js
@@ -1,4 +1,5 @@
 import { canonicalProducts, canonicalLogins } from './product-details';
+import { instantPage } from './instant-page';
 
 function createFromHTML(html) {
   const div = window.document.createElement('div'); //eslint-disable-line
@@ -348,4 +349,7 @@ export const createNav = ({ maxWidth = '68rem', showLogins = true } = {}) => {
 
   // Add event listeners
   addListeners(900, wrapper);
+
+  // Apply just-in-time preloading to links on hover
+  instantPage();
 };

--- a/src/js/instant-page.js
+++ b/src/js/instant-page.js
@@ -1,0 +1,165 @@
+/*! instant.page v1.2.1 - (C) 2019 Alexandre Dieulot - https://instant.page/license */
+
+export const instantPage = () => {
+  let urlToPreload;
+  let mouseoverTimer;
+  let lastTouchTimestamp;
+
+  const prefetcher = document.createElement('link');
+  const isSupported =
+    prefetcher.relList &&
+    prefetcher.relList.supports &&
+    prefetcher.relList.supports('prefetch');
+  const allowQueryString = 'instantAllowQueryString' in document.body.dataset;
+  const allowExternalLinks =
+    'instantAllowExternalLinks' in document.body.dataset;
+
+  if (isSupported) {
+    prefetcher.rel = 'prefetch';
+    document.head.appendChild(prefetcher);
+
+    const eventListenersOptions = {
+      capture: true,
+      passive: true,
+    };
+    document.addEventListener(
+      'touchstart',
+      touchstartListener,
+      eventListenersOptions
+    );
+    document.addEventListener(
+      'mouseover',
+      mouseoverListener,
+      eventListenersOptions
+    );
+  }
+
+  function touchstartListener(event) {
+    /* Chrome on Android calls mouseover before touchcancel so `lastTouchTimestamp`
+     * must be assigned on touchstart to be measured on mouseover. */
+    lastTouchTimestamp = performance.now();
+
+    const linkElement = event.target.closest('a');
+
+    if (!isPreloadable(linkElement)) {
+      return;
+    }
+
+    linkElement.addEventListener(
+      'touchcancel',
+      touchendAndTouchcancelListener,
+      { passive: true }
+    );
+    linkElement.addEventListener('touchend', touchendAndTouchcancelListener, {
+      passive: true,
+    });
+
+    urlToPreload = linkElement.href;
+    preload(linkElement.href);
+  }
+
+  function touchendAndTouchcancelListener() {
+    urlToPreload = undefined;
+    stopPreloading();
+  }
+
+  function mouseoverListener(event) {
+    if (performance.now() - lastTouchTimestamp < 1100) {
+      return;
+    }
+
+    const linkElement = event.target.closest('a');
+
+    if (!isPreloadable(linkElement)) {
+      return;
+    }
+
+    linkElement.addEventListener('mouseout', mouseoutListener, {
+      passive: true,
+    });
+
+    urlToPreload = linkElement.href;
+
+    mouseoverTimer = setTimeout(() => {
+      preload(linkElement.href);
+      mouseoverTimer = undefined;
+    }, 65);
+  }
+
+  function mouseoutListener(event) {
+    if (
+      event.relatedTarget &&
+      event.target.closest('a') == event.relatedTarget.closest('a')
+    ) {
+      return;
+    }
+
+    if (mouseoverTimer) {
+      clearTimeout(mouseoverTimer);
+      mouseoverTimer = undefined;
+    } else {
+      urlToPreload = undefined;
+      stopPreloading();
+    }
+  }
+
+  function isPreloadable(linkElement) {
+    if (!linkElement || !linkElement.href) {
+      return;
+    }
+
+    if (urlToPreload == linkElement.href) {
+      return;
+    }
+
+    const preloadLocation = new URL(linkElement.href);
+
+    if (
+      !allowExternalLinks &&
+      preloadLocation.origin != location.origin &&
+      !('instant' in linkElement.dataset)
+    ) {
+      return;
+    }
+
+    if (!['http:', 'https:'].includes(preloadLocation.protocol)) {
+      return;
+    }
+
+    if (preloadLocation.protocol == 'http:' && location.protocol == 'https:') {
+      return;
+    }
+
+    if (
+      !allowQueryString &&
+      preloadLocation.search &&
+      !('instant' in linkElement.dataset)
+    ) {
+      return;
+    }
+
+    if (
+      preloadLocation.hash &&
+      preloadLocation.pathname + preloadLocation.search ==
+        location.pathname + location.search
+    ) {
+      return;
+    }
+
+    if ('noInstant' in linkElement.dataset) {
+      return;
+    }
+
+    return true;
+  }
+
+  function preload(url) {
+    prefetcher.href = url;
+  }
+
+  function stopPreloading() {
+    /* The spec says an empty string should abort the prefetching
+     * but Firefox 64 interprets it as a relative URL to prefetch. */
+    prefetcher.removeAttribute('href');
+  }
+};

--- a/src/js/instant-page.js
+++ b/src/js/instant-page.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 /*! instant.page v1.2.1 - (C) 2019 Alexandre Dieulot - https://instant.page/license */
 
 export const instantPage = () => {


### PR DESCRIPTION
## Done

Add Instant Page lib for just-in-time preloading on link hover.

Note: will only work on relative links

## QA

- Pull feature branch
- Open terminal in root and run simple server e.g. `python3 -m http.server`
- View site at http://0.0.0.0:8000/
- Hover over link and view network request in server log... it should 404